### PR TITLE
fix: se repara el enlace de la seccion ¿Por que nosotros? en fza

### DIFF
--- a/pages/faq.html
+++ b/pages/faq.html
@@ -24,7 +24,7 @@
                                 <a class="nav-link" href="../index.html#description">Galería</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="index.html#interest">¿Por qué nosotros?</a>
+                                <a class="nav-link" href="../index.html#interest">¿Por qué nosotros?</a>
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="../index.html#contact">Contacto</a>


### PR DESCRIPTION
Se repara la liga que relaciona a la sección de "¿Por qué nosotros?" en la página de Faq